### PR TITLE
Remove incompatible characters in art filename

### DIFF
--- a/UeberPlayer.widget/getTrack.scpt
+++ b/UeberPlayer.widget/getTrack.scpt
@@ -145,7 +145,7 @@ on generateArtFilename(str)
   set charsToCheck to characters of str
   set retList to {}
   repeat with i from 1 to count charsToCheck
-    if {charsToCheck's item i} is not in {" ", "\""} then
+    if {charsToCheck's item i} is not in {" ", "\"", "/", ",", ":", "?"} then
       set retList's end to charsToCheck's item i
     end if
   end repeat


### PR DESCRIPTION
While using the widget, I noticed that some song and album names were generating "invalid" filenames for the artwork, resulting in the cover not being shown at all. 

This fixes it by adding `, \ : ?` to the list of character to exclude when generating the artwork filename.